### PR TITLE
Enable device automations

### DIFF
--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -877,6 +877,8 @@ EASEE_EQ_ENTITIES = {
     },
 }
 
+# When adding or modifying this dict remember to update state,
+# device_triggers and device_conditions in en.json
 EASEE_STATUS = {
     1: "disconnected",
     2: "awaiting_start",

--- a/custom_components/easee/device_action.py
+++ b/custom_components/easee/device_action.py
@@ -1,0 +1,69 @@
+"""Provides device actions for easee_hass."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    ATTR_DEVICE_ID,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_TYPE,
+)
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+
+from . import DOMAIN
+
+ACTION_TYPES = {
+    "override_schedule",
+    "pause",
+    "reboot",
+    "resume",
+    "start",
+    "stop",
+    "toggle",
+}
+
+ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(ACTION_TYPES),
+        vol.Required(CONF_DEVICE_ID): str,
+    }
+)
+
+
+async def async_get_actions(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, str]]:
+    """List device actions for easee_hass devices."""
+    registry = er.async_get(hass)
+    actions = []
+
+    # Get all the integrations entities for this device
+    for entry in er.async_entries_for_device(registry, device_id):
+        if entry.translation_key == "easee_status":
+            # Add actions for each entity that belongs to this integration
+            base_action = {
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+            }
+
+            actions += [{**base_action, CONF_TYPE: act} for act in ACTION_TYPES]
+
+    return actions
+
+
+async def async_call_action_from_config(
+    hass: HomeAssistant, config: dict, variables: dict, context: Context | None
+) -> None:
+    """Execute a device action."""
+    service_data = {
+        ATTR_DEVICE_ID: config[CONF_DEVICE_ID],
+        "action_command": config[CONF_TYPE],
+    }
+
+    service = "action_command"
+
+    await hass.services.async_call(
+        DOMAIN, service, service_data, blocking=True, context=context
+    )

--- a/custom_components/easee/device_condition.py
+++ b/custom_components/easee/device_condition.py
@@ -1,0 +1,70 @@
+"""Provide the device conditions for easee_hass."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_CONDITION,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_TYPE,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import (
+    condition,
+    config_validation as cv,
+    entity_registry as er,
+)
+from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+
+from .const import DOMAIN, EASEE_STATUS
+
+CONDITION_TYPES = list(EASEE_STATUS.values())
+
+CONDITION_SCHEMA = cv.DEVICE_CONDITION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_TYPE): vol.In(CONDITION_TYPES),
+    }
+)
+
+
+async def async_get_conditions(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, str]]:
+    """List device conditions for easee_hass devices."""
+    registry = er.async_get(hass)
+    conditions = []
+
+    # Get all the integrations entities for this device
+    for entry in er.async_entries_for_device(registry, device_id):
+        if entry.translation_key == "easee_status":
+            # Add conditions for each entity that belongs to this integration
+            base_condition = {
+                CONF_CONDITION: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+            }
+            conditions += [
+                {**base_condition, CONF_TYPE: cond} for cond in CONDITION_TYPES
+            ]
+
+    return conditions
+
+
+@callback
+def async_condition_from_config(
+    hass: HomeAssistant, config: ConfigType
+) -> condition.ConditionCheckerType:
+    """Create a function to test a device condition."""
+    state = config[CONF_TYPE]
+
+    @callback
+    def test_is_state(hass: HomeAssistant, variables: TemplateVarsType) -> bool:
+        """Test if an entity is a certain state."""
+        return condition.state(hass, config[ATTR_ENTITY_ID], state)
+
+    return test_is_state

--- a/custom_components/easee/device_trigger.py
+++ b/custom_components/easee/device_trigger.py
@@ -21,11 +21,6 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, EASEE_STATUS
 
-TURNED_DISCONNECTED = "disconnected"
-TURNED_AWAITING_START = "awaiting_start"
-TURNED_CHARGING = "charging"
-TURNED_COMPLETED = "completed"
-
 TRIGGER_TYPES = list(EASEE_STATUS.values())
 
 TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(

--- a/custom_components/easee/device_trigger.py
+++ b/custom_components/easee/device_trigger.py
@@ -1,0 +1,79 @@
+"""Provides device triggers for easee_hass."""
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.components.homeassistant.triggers import state as state_trigger
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_PLATFORM,
+    CONF_TYPE,
+)
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN, EASEE_STATUS
+
+TURNED_DISCONNECTED = "disconnected"
+TURNED_AWAITING_START = "awaiting_start"
+TURNED_CHARGING = "charging"
+TURNED_COMPLETED = "completed"
+
+TRIGGER_TYPES = list(EASEE_STATUS.values())
+
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+    }
+)
+
+
+async def async_get_triggers(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, Any]]:
+    """List device triggers for easee_hass devices."""
+    registry = er.async_get(hass)
+    triggers = []
+
+    # Get all the integrations entities for this device
+    for entry in er.async_entries_for_device(registry, device_id):
+        if entry.translation_key == "easee_status":
+            # Add triggers for each entity that belongs to this integration
+            base_trigger = {
+                CONF_PLATFORM: "device",
+                CONF_DEVICE_ID: device_id,
+                CONF_DOMAIN: DOMAIN,
+                CONF_ENTITY_ID: entry.entity_id,
+            }
+            for state_value in TRIGGER_TYPES:
+                triggers.append({**base_trigger, CONF_TYPE: state_value})
+
+    return triggers
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach a trigger."""
+
+    to_state = config[CONF_TYPE]
+    state_config = {
+        state_trigger.CONF_PLATFORM: "state",
+        CONF_ENTITY_ID: config[CONF_ENTITY_ID],
+        state_trigger.CONF_TO: to_state,
+    }
+    state_config = await state_trigger.async_validate_trigger_config(hass, state_config)
+    return await state_trigger.async_attach_trigger(
+        hass, state_config, action, trigger_info, platform_type="device"
+    )

--- a/custom_components/easee/translations/en.json
+++ b/custom_components/easee/translations/en.json
@@ -29,7 +29,15 @@
     }
   },
   "device_automation": {
-    "action_type": {},
+    "action_type": {
+      "override_schedule": "Override schedule",
+      "pause": "Pause charging",
+      "reboot": "Reboot charger",
+      "resume": "Resume charging",
+      "start": "Start charging",
+      "stop": "Stop charging",
+      "toggle": "Toggle charging"
+    },
     "condition_type": {
       "authenticating": "{entity_name} is authenticating",
       "awaiting_authentication": "{entity_name} is waiting for authentication",

--- a/custom_components/easee/translations/en.json
+++ b/custom_components/easee/translations/en.json
@@ -28,6 +28,59 @@
       }
     }
   },
+  "device_automation": {
+    "action_type": {},
+    "condition_type": {
+      "authenticating": "{entity_name} is authenticating",
+      "awaiting_authentication": "{entity_name} is waiting for authentication",
+      "awaiting_authorization": "{entity_name} is waiting for authorization",
+      "awaiting_load_balancing": "{entity_name} is waiting for load balancing",
+      "awaiting_scheduled_start": "{entity_name} is waiting for scheduled start",
+      "awaiting_smart_start": "{entity_name} is waiting for smart start",
+      "awaiting_start": "{entity_name} is awaiting start",
+      "charging": "{entity_name} is charging",
+      "completed": "{entity_name} is completed",
+      "de_authorizing": "{entity_name} is closing authorization",
+      "disconnected": "{entity_name} is car disconnected",
+      "erratic_ev": "{entity_name} is erratic EV",
+      "error": "{entity_name} is error",
+      "error_dead_powerboard": "{entity_name} is error Dead powerboard",
+      "error_overcurrent": "{entity_name} is error Overcurrent",
+      "error_pen_fault": "{entity_name} is error PEN fault",
+      "error_temperature_too_high": "{entity_name} is error Temperature too high",
+      "offline": "{entity_name} is offline",
+      "paused_due_to_equalizer": "{entity_name} is paused due to Equalizer",
+      "ready_to_charge": "{entity_name} is ready to charge",
+      "searching_for_master": "{entity_name} is searching for master",
+      "start_charging": "{entity_name} is start charging",
+      "stop_charging": "{entity_name} is stop charging"
+    },
+    "trigger_type": {
+      "authenticating": "{entity_name} Authenticating",
+      "awaiting_authentication": "{entity_name} Waiting for authentication",
+      "awaiting_authorization": "{entity_name} Waiting for authorization",
+      "awaiting_load_balancing": "{entity_name} Waiting for load balancing",
+      "awaiting_scheduled_start": "{entity_name} Waiting for scheduled start",
+      "awaiting_smart_start": "{entity_name} Waiting for smart start",
+      "awaiting_start": "{entity_name} Awaiting start",
+      "charging": "{entity_name} Charging",
+      "completed": "{entity_name} Completed",
+      "de_authorizing": "{entity_name} Closing authorization",
+      "disconnected": "{entity_name} Car disconnected",
+      "erratic_ev": "{entity_name} Erratic EV",
+      "error": "{entity_name} Error",
+      "error_dead_powerboard": "{entity_name} Error Dead powerboard",
+      "error_overcurrent": "{entity_name} Error Overcurrent",
+      "error_pen_fault": "{entity_name} Error PEN fault",
+      "error_temperature_too_high": "{entity_name} Error Temperature too high",
+      "offline": "{entity_name} Offline",
+      "paused_due_to_equalizer": "{entity_name} Paused due to Equalizer",
+      "ready_to_charge": "{entity_name} Ready to charge",
+      "searching_for_master": "{entity_name} Searching for master",
+      "start_charging": "{entity_name} Start charging",
+      "stop_charging": "{entity_name} Stop charging"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "basic_schedule": {

--- a/links.sh
+++ b/links.sh
@@ -12,3 +12,5 @@ ln -s custom_components/easee/services.yaml .
 ln -s custom_components/easee/switch.py .
 ln -s custom_components/easee/system_health.py .
 ln -s custom_components/easee/translations .
+ln -s custom_components/easee/device_condition.py .
+ln -s custom_components/easee/device_trigger.py .

--- a/links.sh
+++ b/links.sh
@@ -12,5 +12,6 @@ ln -s custom_components/easee/services.yaml .
 ln -s custom_components/easee/switch.py .
 ln -s custom_components/easee/system_health.py .
 ln -s custom_components/easee/translations .
+ln -s custom_components/easee/device_action.py .
 ln -s custom_components/easee/device_condition.py .
 ln -s custom_components/easee/device_trigger.py .


### PR DESCRIPTION
This PR introduces device_triggers and device_automations to enable the GUI in automations editor for Easee charger devices. The triggers are activated when the selected state is entered irrespective of what the previous state was.
Triggers and conditions are present on device level in the automations editor. I will try to add them also to the status sensor in a follow-up PR.

When this PR is merged, `en.json` should be uploaded to Lokalise to open up for translation to other languages.