### PR TITLE
Reauthenticate when API password is changed

### DIFF
--- a/custom_components/easee/__init__.py
+++ b/custom_components/easee/__init__.py
@@ -6,6 +6,7 @@ from awesomeversion import AwesomeVersion
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from .const import DOMAIN, LISTENER_FN_CLOSE, MIN_HA_VERSION, PLATFORMS, VERSION
 from .controller import Controller
@@ -36,8 +37,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     username = entry.data.get(CONF_USERNAME)
     password = entry.data.get(CONF_PASSWORD)
 
-    controller = Controller(username, password, hass, entry)
-    await controller.initialize()
+    try:
+        controller = Controller(username, password, hass, entry)
+        await controller.initialize()
+    except ConfigEntryAuthFailed as err:
+        raise ConfigEntryAuthFailed from err
+
     hass.data[DOMAIN]["controller"] = controller
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/easee/config_flow.py
+++ b/custom_components/easee/config_flow.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any, Optional
 
 from aiohttp import ClientConnectionError
-from pyeasee import AuthorizationFailedException, Easee, Site
+from pyeasee import AuthorizationFailedException, BadRequestException, Easee, Site
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -32,12 +32,51 @@ class EaseeConfigFlow(config_entries.ConfigFlow):
 
         self.sites = {}
         self.data = {}
+        self.entry = {}
 
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
         return OptionsFlowHandler(config_entry)
+
+    async def async_step_reauth(self, entry_data) -> FlowResult:
+        """Perform reauth upon an API authentication error."""
+        self.entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Dialog that informs the user that reauth is required."""
+        errors = {}
+        if user_input is not None:
+            new_input = self.entry.data | user_input
+            try:
+                client_session = aiohttp_client.async_get_clientsession(self.hass)
+                easee = Easee(
+                    self.entry.data[CONF_USERNAME],
+                    user_input[CONF_PASSWORD],
+                    client_session,
+                )
+                await easee.connect()
+                self.hass.config_entries.async_update_entry(self.entry, data=new_input)
+                await self.hass.config_entries.async_reload(self.entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+            except (AuthorizationFailedException, BadRequestException):
+                errors["base"] = "auth_failure"
+
+            except ConnectionRefusedError:
+                errors["base"] = "refused_failure"
+
+            except ClientConnectionError:
+                errors["base"] = "connection_failure"
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
+            errors=errors,
+        )
 
     async def async_step_user(self, user_input: Optional[ConfigType] = None):
         """Handle a flow start."""

--- a/custom_components/easee/config_flow.py
+++ b/custom_components/easee/config_flow.py
@@ -75,6 +75,7 @@ class EaseeConfigFlow(config_entries.ConfigFlow):
         return self.async_show_form(
             step_id="reauth_confirm",
             data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
+            description_placeholders={"username": self.entry.data[CONF_USERNAME]},
             errors=errors,
         )
 

--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -22,6 +22,7 @@ from pyeasee import (
 )
 from pyeasee.exceptions import (
     AuthorizationFailedException,
+    BadRequestException,
     NotFoundException,
     ServerFailureException,
     TooManyRequestsException,
@@ -29,7 +30,7 @@ from pyeasee.exceptions import (
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady, Unauthorized
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.event import (
     async_track_time_change,
@@ -453,10 +454,16 @@ class Controller:
             _LOGGER.debug("Easee server too many requests")
             raise ConfigEntryNotReady from err
         except AuthorizationFailedException as err:
-            _LOGGER.error("Authorization failed to easee")
-            raise Unauthorized from err
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.error("Unexpected error creating device")
+            _LOGGER.error("Authorization failed to easee #1")
+            raise ConfigEntryAuthFailed from err
+        except BadRequestException as err:
+            if err.args[0]["errorCode"] == 100:
+                _LOGGER.error("Authorization failed to easee #2")
+                raise ConfigEntryAuthFailed from err
+            else:
+                _LOGGER.error("Bad request %s", err)
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected error creating device: %s", err)
             return None
 
         try:

--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -454,11 +454,11 @@ class Controller:
             _LOGGER.debug("Easee server too many requests")
             raise ConfigEntryNotReady from err
         except AuthorizationFailedException as err:
-            _LOGGER.error("Authorization failed to easee #1")
+            _LOGGER.error("Authorization failed to Easee")
             raise ConfigEntryAuthFailed from err
         except BadRequestException as err:
             if err.args[0]["errorCode"] == 100:
-                _LOGGER.error("Authorization failed to easee #2")
+                _LOGGER.error("Authorization (username/password) failed to Easee")
                 raise ConfigEntryAuthFailed from err
             else:
                 _LOGGER.error("Bad request %s", err)

--- a/custom_components/easee/translations/en.json
+++ b/custom_components/easee/translations/en.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_setup": "You can only configure a single Easee connection."
+      "already_setup": "You can only configure a single Easee connection.",
+      "reauth_successful": "Reauthentication successful."
     },
     "error": {
       "auth_failure": "Unable to connect to Easee. Check your username and password.",
@@ -11,6 +12,13 @@
       "refused_failure": "Connection refused to Easee. Test again later."
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "password": "Password"
+        },
+        "description": "The Easee integration needs to reauthenticate your account.",
+        "title": "Re-authenticate with Easee"
+      },
       "sites": {
         "data": {
           "monitored_sites": "Sites"

--- a/custom_components/easee/translations/en.json
+++ b/custom_components/easee/translations/en.json
@@ -16,7 +16,7 @@
         "data": {
           "password": "Password"
         },
-        "description": "The Easee integration needs to reauthenticate your account.",
+        "description": "The Easee integration needs to re-authenticate the account {username}.",
         "title": "Re-authenticate with Easee"
       },
       "sites": {


### PR DESCRIPTION
If the API password is changed, a request for reathentication will be triggered. The user will just have to enter the new password and thus no need for uninstall/Install in this situation anymore.