### PR TITLE
Remove some non working sensors from slave chargers

### DIFF
--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -462,6 +462,7 @@ OPTIONAL_EASEE_ENTITIES = {
             )
         ),
         "enabled_default": False,
+        "only_master": True,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
     "max_circuit_limit": {

--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -436,6 +436,7 @@ OPTIONAL_EASEE_ENTITIES = {
             )
         ),
         "enabled_default": False,
+        "only_master": True,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
     "dynamic_circuit_limit": {
@@ -489,6 +490,7 @@ OPTIONAL_EASEE_ENTITIES = {
             )
         ),
         "enabled_default": False,
+        "only_master": True,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
     "dynamic_charger_limit": {
@@ -529,6 +531,7 @@ OPTIONAL_EASEE_ENTITIES = {
             )
         ),
         "enabled_default": False,
+        "only_master": True,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
     "max_charger_limit": {


### PR DESCRIPTION
Since slave chargers does not provide correct values for the dynamic_circuit_limit sensors, it is better to remove it.