### PR TITLE
Update dev env to python3.12 and bump dependencies

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,57 +1,52 @@
 {
-	"name": "dev-easee",
-	"image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.11-bullseye",
-	"postCreateCommand": "scripts/setup",
-	"appPort": [
-		"9125:8123"
-	],
-	"portsAttributes": {
-		"8123": {
-			"label": "Home Assistant internal",
-			"onAutoForward": "notify"
-		},
-		"9125": {
-			"label": "Home Assistant remote",
-			"onAutoForward": "notify"
-		}
-	},
-	"customizations": {
-		"vscode": {
-			"extensions": [
-				"ms-python.python",
-				"github.vscode-pull-request-github",
-				"ryanluker.vscode-coverage-gutters",
-				"ms-python.vscode-pylance",
-				"ms-python.pylint",
-				"charliermarsh.ruff",
-				"thibault-vanderseypen.i18n-json-editor"
-			],
-			"settings": {
-				"files.eol": "\n",
-				"editor.tabSize": 4,
-				"python.pythonPath": "/usr/bin/python3",
-				"python.analysis.autoSearchPaths": false,
-				"[python]": {
-					"editor.defaultFormatter": "charliermarsh.ruff",
-					"editor.formatOnSave": true
-				},
-				"editor.formatOnPaste": false,
-				"editor.formatOnSave": true,
-				"editor.formatOnType": true,
-				"files.trimTrailingWhitespace": true,
-				"[markdown]": {
-					"files.trimTrailingWhitespace": false
-				},
-				"i18nJsonEditor.forceKeyUPPERCASE": false,
-				"i18nJsonEditor.supportedFolders": [
-					"translations",
-					"i18n"
-				]
-			}
-		}
-	},
-	"remoteUser": "vscode",
-	"features": {
-		"ghcr.io/devcontainers/features/rust:1": {}
-	}
+  "name": "dev-easee",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.12",
+  "postCreateCommand": "scripts/setup",
+  "appPort": [
+    "9125:8123"
+  ],
+  "portsAttributes": {
+    "8123": {
+      "label": "Home Assistant internal",
+      "onAutoForward": "notify"
+    },
+    "9125": {
+      "label": "Home Assistant remote",
+      "onAutoForward": "notify"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+          "ms-python.python",
+          "github.vscode-pull-request-github",
+          "ryanluker.vscode-coverage-gutters",
+          "ms-python.vscode-pylance",
+          "ms-python.pylint",
+          "charliermarsh.ruff"
+      ],
+      "settings": {
+        "files.eol": "\n",
+        "editor.tabSize": 4,
+        "python.pythonPath": "/usr/bin/python3",
+        "python.analysis.autoSearchPaths": false,
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.formatOnSave": true
+        },
+        "editor.formatOnPaste": false,
+        "editor.formatOnSave": true,
+        "editor.formatOnType": true,
+        "files.trimTrailingWhitespace": true,
+        "[markdown]": {
+          "files.trimTrailingWhitespace": false
+        }
+      }
+    }
+  },
+  "remoteUser": "vscode",
+  "features": {
+    "ghcr.io/devcontainers/features/rust:1": {},
+    "ghcr.io/devcontainers-contrib/features/ffmpeg-apt-get:1": {}
+  }
 }

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,0 +1,15 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+    - package-ecosystem: 'github-actions'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+
+    - package-ecosystem: 'pip'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+      ignore:
+          # Dependabot should not update Home Assistant as that should match the homeassistant key in hacs.json
+          - dependency-name: 'homeassistant'

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -10,5 +10,5 @@ jobs:
   validate:
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: 'actions/checkout@v3.3.0'
+      - uses: 'actions/checkout@v4.1.2'
       - uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v4.1.2
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.2
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
@@ -23,7 +23,7 @@ jobs:
           cd ${{ github.workspace }}/custom_components/easee
           zip easee.zip -r ./
       - name: Upload zip to release
-        uses: svenstaro/upload-release-action@2.7.0
+        uses: svenstaro/upload-release-action@2.9.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ github.workspace }}/custom_components/easee/easee.zip

--- a/.github/workflows/validate_hacs.yaml
+++ b/.github/workflows/validate_hacs.yaml
@@ -10,7 +10,7 @@ jobs:
   validate:
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: 'actions/checkout@v3.3.0'
+      - uses: 'actions/checkout@v4.1.2'
       - name: HACS validation
         uses: 'hacs/action@main'
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.0.278
+      rev: v0.3.3
       hooks:
           - id: ruff
             args:
@@ -13,7 +13,7 @@ repos:
                 - --quiet
             files: ^((custom_components|homeassistant|pylint|script|tests)/.+)?[^/]+\.py$
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.4.0
+      rev: v4.5.0
       hooks:
           - id: trailing-whitespace
           - id: end-of-file-fixer

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,110 +1,138 @@
 # The contents of this file is based on https://github.com/home-assistant/core/blob/dev/pyproject.toml
 
-target-version = "py310"
+target-version = "py312"
 
-select = [
-    "B002",    # Python does not support the unary prefix increment
-    "B007",    # Loop control variable {name} not used within loop body
-    "B014",    # Exception handler with duplicate exception
-    "B023",    # Function definition does not bind loop variable {name}
-    "B026",    # Star-arg unpacking after a keyword argument is strongly discouraged
-    "C",       # complexity
-    "COM818",  # Trailing comma on bare tuple prohibited
-    "D",       # docstrings
-    "E",       # pycodestyle
-    "F",       # pyflakes/autoflake
-    "G",       # flake8-logging-format
-    "I",       # isort
-    "ICN001",  # import concentions; {name} should be imported as {asname}
-    "ISC001",  # Implicitly concatenated string literals on one line
-    "N804",    # First argument of a class method should be named cls
-    "N805",    # First argument of a method should be named self
-    "N815",    # Variable {name} in class scope should not be mixedCase
-    "PGH001",  # No builtin eval() allowed
-    "PGH004",  # Use specific rule codes when using noqa
-    "PLC0414", # Useless import alias. Import alias does not rename original package.
-    "PLC",     # pylint
-    "PLE",     # pylint
-    "PLR",     # pylint
-    "PLW",     # pylint
-    "Q000",    # Double quotes found but single quotes preferred
-    "RUF006",  # Store a reference to the return value of asyncio.create_task
-    "S102",    # Use of exec detected
-    "S103",    # bad-file-permissions
-    "S108",    # hardcoded-temp-file
-    "S306",    # suspicious-mktemp-usage
-    "S307",    # suspicious-eval-usage
-    "S313",    # suspicious-xmlc-element-tree-usage
-    "S314",    # suspicious-xml-element-tree-usage
-    "S315",    # suspicious-xml-expat-reader-usage
-    "S316",    # suspicious-xml-expat-builder-usage
-    "S317",    # suspicious-xml-sax-usage
-    "S318",    # suspicious-xml-mini-dom-usage
-    "S319",    # suspicious-xml-pull-dom-usage
-    "S320",    # suspicious-xmle-tree-usage
-    "S601",    # paramiko-call
-    "S602",    # subprocess-popen-with-shell-equals-true
-    "S604",    # call-with-shell-equals-true
-    "S608",    # hardcoded-sql-expression
-    "S609",    # unix-command-wildcard-injection
-    "SIM105",  # Use contextlib.suppress({exception}) instead of try-except-pass
-    "SIM117",  # Merge with-statements that use the same scope
-    "SIM118",  # Use {key} in {dict} instead of {key} in {dict}.keys()
-    "SIM201",  # Use {left} != {right} instead of not {left} == {right}
-    "SIM208",  # Use {expr} instead of not (not {expr})
-    "SIM212",  # Use {a} if {a} else {b} instead of {b} if not {a} else {a}
-    "SIM300",  # Yoda conditions. Use 'age == 42' instead of '42 == age'.
-    "SIM401",  # Use get from dict with default instead of an if block
-    "T100",    # Trace found: {name} used
-    "T20",     # flake8-print
-    "TID251",  # Banned imports
-    "TRY004",  # Prefer TypeError exception for invalid type
-    "TRY200",  # Use raise from to specify exception cause
-    "TRY302",  # Remove exception handler; error is immediately re-raised
-    "UP",      # pyupgrade
-    "W",       # pycodestyle
+lint.select = [
+    "B002",   # Python does not support the unary prefix increment
+    "B005",   # Using .strip() with multi-character strings is misleading
+    "B007",   # Loop control variable {name} not used within loop body
+    "B014",   # Exception handler with duplicate exception
+    "B015",   # Pointless comparison. Did you mean to assign a value? Otherwise, prepend assert or remove it.
+    "B018",   # Found useless attribute access. Either assign it to a variable or remove it.
+    "B023",   # Function definition does not bind loop variable {name}
+    "B026",   # Star-arg unpacking after a keyword argument is strongly discouraged
+    "B032",   # Possible unintentional type annotation (using :). Did you mean to assign (using =)?
+    "B904",   # Use raise from to specify exception cause
+    "C",      # complexity
+    "COM818", # Trailing comma on bare tuple prohibited
+    "D",      # docstrings
+    "DTZ003", # Use datetime.now(tz=) instead of datetime.utcnow()
+    "DTZ004", # Use datetime.fromtimestamp(ts, tz=) instead of datetime.utcfromtimestamp(ts)
+    "E",      # pycodestyle
+    "F",      # pyflakes/autoflake
+    "G",      # flake8-logging-format
+    "I",      # isort
+    "ISC",    # flake8-implicit-str-concat
+    "ICN001", # import concentions; {name} should be imported as {asname}
+    "LOG",    # flake8-logging
+    "N804",   # First argument of a class method should be named cls
+    "N805",   # First argument of a method should be named self
+    "N815",   # Variable {name} in class scope should not be mixedCase
+    "PERF",   # Perflint
+    "PGH004", # Use specific rule codes when using noqa
+    "PIE",    # flake8-pie
+    "PL",     # pylint
+    "PT",     # flake8-pytest-style
+    "RSE",    # flake8-raise
+    "RUF005", # Consider iterable unpacking instead of concatenation
+    "RUF006", # Store a reference to the return value of asyncio.create_task
+    # "RUF100", # Unused `noqa` directive; temporarily every now and then to clean them up
+    "S102",   # Use of exec detected
+    "S103",   # bad-file-permissions
+    "S108",   # hardcoded-temp-file
+    "S306",   # suspicious-mktemp-usage
+    "S307",   # suspicious-eval-usage
+    "S313",   # suspicious-xmlc-element-tree-usage
+    "S314",   # suspicious-xml-element-tree-usage
+    "S315",   # suspicious-xml-expat-reader-usage
+    "S316",   # suspicious-xml-expat-builder-usage
+    "S317",   # suspicious-xml-sax-usage
+    "S318",   # suspicious-xml-mini-dom-usage
+    "S319",   # suspicious-xml-pull-dom-usage
+    "S320",   # suspicious-xmle-tree-usage
+    "S601",   # paramiko-call
+    "S602",   # subprocess-popen-with-shell-equals-true
+    "S604",   # call-with-shell-equals-true
+    "S608",   # hardcoded-sql-expression
+    "S609",   # unix-command-wildcard-injection
+    "SIM",    # flake8-simplify
+    "T100",   # Trace found: {name} used
+    "T20",    # flake8-print
+    "TID251", # Banned imports
+    "TRY004", # Prefer TypeError exception for invalid type
+    "TRY302", # Remove exception handler; error is immediately re-raised
+    "UP",     # pyupgrade
+    "W",      # pycodestyle
 ]
 
-ignore = [
-    "D202",    # No blank lines allowed after function docstring
-    "D203",    # 1 blank line required before class docstring
-    "D213",    # Multi-line docstring summary should start at the second line
-    "D406",    # Section name should end with a newline
-    "D407",    # Section name underlining
-    "E501",    # line too long
-    "E731",    # do not assign a lambda expression, use a def
-    "PLC1901", # Lots of false positives
-    # False positives https://github.com/astral-sh/ruff/issues/5386
-    "PLC0208", # Use a sequence type instead of a `set` when iterating over values
+lint.ignore = [
+    "D202", # No blank lines allowed after function docstring
+    "D203", # 1 blank line required before class docstring
+    "D213", # Multi-line docstring summary should start at the second line
+    "D406", # Section name should end with a newline
+    "D407", # Section name underlining
+    "E501", # line too long
+    "E731", # do not assign a lambda expression, use a def
+
+    "PLC1901", # {existing} can be simplified to {replacement} as an empty string is falsey; too many false positives
     "PLR0911", # Too many return statements ({returns} > {max_returns})
     "PLR0912", # Too many branches ({branches} > {max_branches})
     "PLR0913", # Too many arguments to function call ({c_args} > {max_args})
     "PLR0915", # Too many statements ({statements} > {max_statements})
     "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
     "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
+    "SIM102",  # Use a single if statement instead of nested if statements
+    "SIM108",  # Use ternary operator {contents} instead of if-else-block
+    "SIM115",  # Use context handler for opening files
     "UP006",   # keep type annotation style as is
     "UP007",   # keep type annotation style as is
     # Ignored due to performance: https://github.com/charliermarsh/ruff/issues/2923
     "UP038", # Use `X | Y` in `isinstance` call instead of `(X, Y)`
 
+    # May conflict with the formatter, https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "W191",
+    "E111",
+    "E114",
+    "E117",
+    "D206",
+    "D300",
+    "Q",
+    "COM812",
+    "COM819",
+    "ISC001",
+
+    # Disabled because ruff does not understand type of __all__ generated by a function
+    "PLE0605",
+
+    # temporarily disabled
+    "PT004",
+    "PT007",
+    "PT011",
+    "PT018",
+    "PT012",
+    "PT023",
+    "PT019",
 ]
 
-[flake8-import-conventions.extend-aliases]
+[lint.flake8-import-conventions.extend-aliases]
 voluptuous = "vol"
 "homeassistant.helpers.area_registry" = "ar"
+"homeassistant.helpers.category_registry" = "cr"
 "homeassistant.helpers.config_validation" = "cv"
 "homeassistant.helpers.device_registry" = "dr"
 "homeassistant.helpers.entity_registry" = "er"
+"homeassistant.helpers.floor_registry" = "fr"
 "homeassistant.helpers.issue_registry" = "ir"
+"homeassistant.helpers.label_registry" = "lr"
 "homeassistant.util.dt" = "dt_util"
 
-[isort]
+[lint.isort]
 force-sort-within-sections = true
 known-first-party = ["homeassistant"]
 combine-as-imports = true
 
-[flake8-pytest-style]
+[lint.flake8-pytest-style]
 fixture-parentheses = false
 
-[mccabe]
+[lint.mccabe]
 max-complexity = 25

--- a/requirements-devcontainer.txt
+++ b/requirements-devcontainer.txt
@@ -1,5 +1,5 @@
-colorlog==6.7.0
-ruff==0.1.3
+colorlog==6.8.2
+ruff==0.3.3
 bump2version
 wheel
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-colorlog==6.7.0
+colorlog==6.8.2
 homeassistant
-pip>=21.0,<23.3
-ruff==0.1.3
-pre-commit==3.5.0
+pip>=21.0,<24.1
+ruff==0.3.3
+pre-commit==3.6.2
 bump2version==1.0.1
 
 pyeasee


### PR DESCRIPTION
Update dev container to python3.12 as earlier versions are unsupported from HA 2024.4.
Update ruff linter to 3.3 and align rules with HA 2024.4
