### PR TITLE
Add icon translations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,13 +5,6 @@ repos:
           - id: ruff
             args:
                 - --fix
-    - repo: https://github.com/psf/black
-      rev: 23.1.0
-      hooks:
-          - id: black
-            args:
-                - --quiet
-            files: ^((custom_components|homeassistant|pylint|script|tests)/.+)?[^/]+\.py$
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.4.0
       hooks:

--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -1,5 +1,7 @@
 """Easee Charger constants."""
 
+# pylint: disable=too-many-lines
+
 from pyeasee import ChargerStreamData, EqualizerStreamData
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass

--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -1,4 +1,5 @@
 """Easee Charger constants."""
+
 from pyeasee import ChargerStreamData, EqualizerStreamData
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
@@ -200,8 +201,6 @@ MANDATORY_EASEE_ENTITIES = {
         "units": None,
         "convert_units_func": "map_charger_status",
         "device_class": None,
-        # "device_class": "easee__status",
-        "icon": "mdi:ev-station",
         "translation_key": "easee_status",
     },
 }
@@ -214,7 +213,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": None,
         "translation_key": "smart_charging",
         "device_class": None,
-        "icon": "mdi:auto-fix",
         "switch_func": "smart_charging",
         "enabled_default": True,
         "entity_category": EntityCategory.CONFIG,
@@ -227,7 +225,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": None,
         "translation_key": "smart_button",
         "device_class": None,
-        "icon": "mdi:gesture-tap-button",
         "switch_func": "smartButtonEnabled",
         "enabled_default": True,
         "entity_category": EntityCategory.CONFIG,
@@ -240,7 +237,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": None,
         "translation_key": "cable_locked",
         "device_class": BinarySensorDeviceClass.LOCK,
-        "icon": None,
         "state_func": lambda state: not bool(state["cableLocked"]),
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
@@ -252,7 +248,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": None,
         "translation_key": "cable_locked_permanently",
         "device_class": None,
-        "icon": "mdi:lock",
         "switch_func": "lockCablePermanently",
         "enabled_default": True,
         "entity_category": EntityCategory.CONFIG,
@@ -266,7 +261,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "state_class": SensorStateClass.MEASUREMENT,
         "translation_key": "power",
         "suggested_display_precision": 1,
-        "icon": None,
     },
     "session_energy": {
         "key": "state.sessionEnergy",
@@ -276,7 +270,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "suggested_display_precision": 1,
         "translation_key": "session_energy",
         "device_class": SensorDeviceClass.ENERGY,
-        "icon": None,
         "enabled_default": True,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
@@ -289,7 +282,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "translation_key": "lifetime_energy",
         "device_class": SensorDeviceClass.ENERGY,
         "state_class": SensorStateClass.TOTAL_INCREASING,
-        "icon": "mdi:counter",
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
     "energy_per_hour": {
@@ -300,7 +292,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "suggested_display_precision": 1,
         "translation_key": "energy_per_hour",
         "device_class": SensorDeviceClass.ENERGY,
-        "icon": None,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
     "cost_day": {
@@ -315,7 +306,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "suggested_display_precision": 2,
         "translation_key": "cost_day",
         "device_class": SensorDeviceClass.MONETARY,
-        "icon": None,
         "enabled_default": True,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
@@ -331,7 +321,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "suggested_display_precision": 2,
         "translation_key": "cost_month",
         "device_class": SensorDeviceClass.MONETARY,
-        "icon": None,
         "enabled_default": True,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
@@ -347,7 +336,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "suggested_display_precision": 2,
         "translation_key": "cost_year",
         "device_class": SensorDeviceClass.MONETARY,
-        "icon": None,
         "enabled_default": True,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
@@ -367,7 +355,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": None,
         "translation_key": "online",
         "device_class": BinarySensorDeviceClass.CONNECTIVITY,
-        "icon": None,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
     "output_limit": {
@@ -378,7 +365,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "suggested_display_precision": 1,
         "translation_key": "output_limit",
         "device_class": SensorDeviceClass.CURRENT,
-        "icon": None,
         "enabled_default": False,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
@@ -396,7 +382,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "translation_key": "current",
         "device_class": SensorDeviceClass.CURRENT,
         "state_class": SensorStateClass.MEASUREMENT,
-        "icon": None,
         "state_func": lambda state: float(
             max(
                 state["inCurrentT2"],
@@ -427,7 +412,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "suggested_display_precision": 1,
         "translation_key": "circuit_current",
         "device_class": SensorDeviceClass.CURRENT,
-        "icon": None,
         "state_func": lambda state: float(
             max(
                 state["circuitTotalPhaseConductorCurrentL1"]
@@ -457,7 +441,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "suggested_display_precision": 0,
         "translation_key": "equalizer_limit",
         "device_class": SensorDeviceClass.CURRENT,
-        "icon": None,
         "state_func": lambda state: float(
             max(
                 state["eqAvailableCurrentP1"],
@@ -484,7 +467,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": "round_0_dec",
         "translation_key": "dynamic_circuit_limit",
         "device_class": SensorDeviceClass.CURRENT,
-        "icon": None,
         "state_func": lambda state: float(
             max(
                 state["dynamicCircuitCurrentP1"],
@@ -511,7 +493,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": "round_0_dec",
         "translation_key": "max_circuit_limit",
         "device_class": SensorDeviceClass.CURRENT,
-        "icon": None,
         "state_func": lambda config: float(
             max(
                 config["circuitMaxCurrentP1"],
@@ -532,7 +513,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": "round_0_dec",
         "translation_key": "dynamic_charger_limit",
         "device_class": SensorDeviceClass.CURRENT,
-        "icon": None,
         "enabled_default": False,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
@@ -552,7 +532,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "suggested_display_precision": 0,
         "translation_key": "offline_circuit_limit",
         "device_class": SensorDeviceClass.CURRENT,
-        "icon": None,
         "state_func": lambda state: float(
             max(
                 state["offlineMaxCircuitCurrentP1"],
@@ -573,7 +552,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": "round_0_dec",
         "translation_key": "max_charger_limit",
         "device_class": SensorDeviceClass.CURRENT,
-        "icon": None,
         "enabled_default": False,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
@@ -597,7 +575,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "device_class": SensorDeviceClass.VOLTAGE,
         "translation_key": "voltage",
         "state_class": SensorStateClass.MEASUREMENT,
-        "icon": None,
         "enabled_default": False,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
@@ -607,7 +584,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "units": None,
         "convert_units_func": "map_reason_no_current",
         "device_class": "easee__reason_no_current",
-        "icon": "mdi:alert-circle",
         "enabled_default": False,
         "translation_key": "easee_reason_no_current",
     },
@@ -618,7 +594,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "units": None,
         "convert_units_func": None,
         "device_class": None,
-        "icon": "mdi:power-standby",
         "switch_func": "enable_charger",
         "translation_key": "is_enabled",
     },
@@ -630,7 +605,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": None,
         "translation_key": "idle_current",
         "device_class": None,
-        "icon": "mdi:current-ac",
         "switch_func": "enable_idle_current",
         "entity_category": EntityCategory.CONFIG,
     },
@@ -645,7 +619,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": None,
         "translation_key": "update_available",
         "device_class": None,
-        "icon": "mdi:file-download",
         "state_func": lambda state: (
             int(state["chargerFirmware"]) < int(state["latestFirmware"])
         )
@@ -667,7 +640,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": None,
         "device_class": None,
         "translation_key": "basic_schedule",
-        "icon": "mdi:clock-check",
         "state_func": lambda schedule: bool(schedule.isEnabled) or False,
         "enabled_default": False,
         "entity_category": EntityCategory.DIAGNOSTIC,
@@ -696,7 +668,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": None,
         "translation_key": "weekly_schedule",
         "device_class": None,
-        "icon": "mdi:clock-check",
         "state_func": lambda weekly_schedule: bool(weekly_schedule.isEnabled) or False,
         "enabled_default": False,
         "entity_category": EntityCategory.DIAGNOSTIC,
@@ -714,7 +685,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "convert_units_func": None,
         "translation_key": "cost_per_kwh",
         "device_class": SensorDeviceClass.MONETARY,
-        "icon": None,
         "enabled_default": False,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
@@ -727,7 +697,6 @@ OPTIONAL_EASEE_ENTITIES = {
         "translation_key": "internal_temperature",
         "device_class": SensorDeviceClass.TEMPERATURE,
         "state_class": SensorStateClass.MEASUREMENT,
-        "icon": None,
         "enabled_default": True,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
@@ -750,7 +719,6 @@ EASEE_EQ_ENTITIES = {
         "convert_units_func": None,
         "translation_key": "online",
         "device_class": BinarySensorDeviceClass.CONNECTIVITY,
-        "icon": None,
     },
     "import_power": {
         "key": "state.activePowerImport",
@@ -763,7 +731,6 @@ EASEE_EQ_ENTITIES = {
         "translation_key": "import_power",
         "device_class": SensorDeviceClass.POWER,
         "state_class": SensorStateClass.MEASUREMENT,
-        "icon": None,
     },
     "import_reactive_power": {
         "key": "state.reactivePowerImport",
@@ -777,7 +744,6 @@ EASEE_EQ_ENTITIES = {
         # support kVAr, so we can not use it.
         "device_class": SensorDeviceClass.POWER,
         "state_class": SensorStateClass.MEASUREMENT,
-        "icon": None,
     },
     "export_power": {
         "key": "state.activePowerExport",
@@ -788,7 +754,6 @@ EASEE_EQ_ENTITIES = {
         "translation_key": "export_power",
         "device_class": SensorDeviceClass.POWER,
         "state_class": SensorStateClass.MEASUREMENT,
-        "icon": None,
     },
     "export_reactive_power": {
         "key": "state.reactivePowerExport",
@@ -802,7 +767,6 @@ EASEE_EQ_ENTITIES = {
         # support kVAr, so we can not use it.
         "device_class": SensorDeviceClass.POWER,
         "state_class": SensorStateClass.MEASUREMENT,
-        "icon": None,
     },
     "voltage": {
         "key": "state.voltageNL1",
@@ -820,7 +784,6 @@ EASEE_EQ_ENTITIES = {
         "translation_key": "voltage",
         "device_class": SensorDeviceClass.VOLTAGE,
         "state_class": SensorStateClass.MEASUREMENT,
-        "icon": None,
         "state_func": lambda state: float(
             max(
                 state["voltageNL1"] or 0.0,
@@ -847,7 +810,6 @@ EASEE_EQ_ENTITIES = {
         "translation_key": "current",
         "device_class": SensorDeviceClass.CURRENT,
         "state_class": SensorStateClass.MEASUREMENT,
-        "icon": None,
         "state_func": lambda state: float(
             max(
                 state["currentL1"],
@@ -867,7 +829,6 @@ EASEE_EQ_ENTITIES = {
         "translation_key": "import_energy",
         "device_class": SensorDeviceClass.ENERGY,
         "state_class": SensorStateClass.TOTAL_INCREASING,
-        "icon": None,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
     "import_reactive_energy": {
@@ -881,7 +842,6 @@ EASEE_EQ_ENTITIES = {
         # Note, at the time of writing there is no REACTIVE_ENERGY class
         "device_class": SensorDeviceClass.ENERGY,
         "state_class": SensorStateClass.TOTAL_INCREASING,
-        "icon": None,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
     "export_energy": {
@@ -893,7 +853,6 @@ EASEE_EQ_ENTITIES = {
         "translation_key": "export_energy",
         "device_class": SensorDeviceClass.ENERGY,
         "state_class": SensorStateClass.TOTAL_INCREASING,
-        "icon": None,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
     "export_reactive_energy": {
@@ -907,7 +866,6 @@ EASEE_EQ_ENTITIES = {
         # Note, at the time of writing there is no REACTIVE_ENERGY class
         "device_class": SensorDeviceClass.ENERGY,
         "state_class": SensorStateClass.TOTAL_INCREASING,
-        "icon": None,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
     "temp_max": {
@@ -919,7 +877,6 @@ EASEE_EQ_ENTITIES = {
         "translation_key": "internal_temperature",
         "device_class": SensorDeviceClass.TEMPERATURE,
         "state_class": SensorStateClass.MEASUREMENT,
-        "icon": None,
         "enabled_default": True,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },

--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -1,4 +1,5 @@
 """Easee Connector class."""
+
 import asyncio
 from datetime import timedelta
 from gc import collect
@@ -195,7 +196,9 @@ class ProductData:
                 name = self.streamdata(data_id).name
             except ValueError:
                 # Unsupported data
-                _LOGGER.debug("Unsupported data id %s %s %s", self.product.id, data_id, value)
+                _LOGGER.debug(
+                    "Unsupported data id %s %s %s", self.product.id, data_id, value
+                )
                 return False
 
             _LOGGER.debug(
@@ -322,7 +325,7 @@ class ProductData:
         try:
             if abs(reference - value) > abs(reference * MINIMUM_UPDATE):
                 return True
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             return True
 
         return False
@@ -362,7 +365,9 @@ class ProductData:
             name = self.streamdata(data_id).name
         except ValueError:
             # Unsupported data
-            _LOGGER.debug("Unsupported data id %s %s %s", self.product.id, data_id, value)
+            _LOGGER.debug(
+                "Unsupported data id %s %s %s", self.product.id, data_id, value
+            )
             return False
 
         _LOGGER.debug(
@@ -372,7 +377,7 @@ class ProductData:
         if "_" in name:
             try:
                 first, second = name.split("_")
-            except Exception as ex:
+            except Exception as ex:  # pylint: disable=broad-except
                 _LOGGER.print("Exception %s when splitting %s", ex, name)
                 return False
 
@@ -466,7 +471,7 @@ class Controller:
         try:
             with timeout(TIMEOUT):
                 await self.easee.connect()
-        except asyncio.TimeoutError as err:
+        except TimeoutError as err:
             _LOGGER.debug("Connection to easee login timed out")
             raise ConfigEntryNotReady from err
         except ServerFailureException as err:
@@ -680,7 +685,7 @@ class Controller:
         _LOGGER.debug("Hour refresh started")
 
         for equalizer in self.equalizers_data:
-            await equalizer.async_refresh(poll_observations = equalizerEnergyObservations)
+            await equalizer.async_refresh(poll_observations=equalizerEnergyObservations)
 
         self.update_ha_state()
 
@@ -835,19 +840,16 @@ class Controller:
             name=name,
             state_key=data["key"],
             units=data["units"],
-            convert_units_func=convert_units_funcs.get(
-                data["convert_units_func"], None
-            ),
+            convert_units_func=convert_units_funcs.get(data["convert_units_func"]),
             attrs_keys=data["attrs"],
             device_class=data["device_class"],
             translation_key=data.get("translation_key"),
             suggested_display_precision=data.get("suggested_display_precision"),
-            state_class=data.get("state_class", None),
-            icon=data["icon"],
-            state_func=data.get("state_func", None),
-            switch_func=data.get("switch_func", None),
+            state_class=data.get("state_class"),
+            state_func=data.get("state_func"),
+            switch_func=data.get("switch_func"),
             enabled_default=data.get("enabled_default", True),
-            entity_category=data.get("entity_category", None),
+            entity_category=data.get("entity_category"),
         )
         _LOGGER.debug(
             "Adding entity: %s (%s) for product %s, unit %s",

--- a/custom_components/easee/entity.py
+++ b/custom_components/easee/entity.py
@@ -2,6 +2,7 @@
 
 Author: Niklas Fondberg<niklas.fondberg@gmail.com>.
 """
+
 from collections.abc import Callable
 from datetime import datetime
 import logging
@@ -78,7 +79,6 @@ class ChargerEntity(Entity):
         convert_units_func: Callable,
         attrs_keys: list[str],
         device_class: str,
-        icon: str,
         state_func=None,
         switch_func=None,
         enabled_default=True,
@@ -102,7 +102,6 @@ class ChargerEntity(Entity):
         self._attr_device_class = device_class
         self._attr_translation_key = translation_key
         self._attr_suggested_display_precision = suggested_display_precision
-        self._attr_icon = icon
         self._attr_should_poll = False
         self._attr_entity_registry_enabled_default = enabled_default
         if translation_key is None:
@@ -178,11 +177,7 @@ class ChargerEntity(Entity):
                     attrs[key] = round_0_dec(self.get_value_from_key(attr_key))
                 elif "current" in key.lower():
                     attrs[key] = round_1_dec(self.get_value_from_key(attr_key))
-                elif "cumulative" in key.lower():
-                    attrs[key] = round_1_dec(
-                        self.get_value_from_key(attr_key), self._units
-                    )
-                elif "power" in key.lower():
+                elif "cumulative" in key.lower() or "power" in key.lower():
                     attrs[key] = round_1_dec(
                         self.get_value_from_key(attr_key), self._units
                     )

--- a/custom_components/easee/icons.json
+++ b/custom_components/easee/icons.json
@@ -1,0 +1,56 @@
+{
+    "entity": {
+        "binary_sensor": {
+            "update_available": {
+                "default": "mdi:file-download"
+            },
+            "basic_schedule": {
+                "default": "mdi:clock-check"
+            },
+            "weekly_schedule": {
+                "default": "mdi:clock-check"
+            }
+        },
+        "sensor": {
+            "easee_status": {
+                "default": "mdi:ev-station"
+            },
+            "lifetime_energy": {
+                "default": "mdi:counter"
+            },
+            "easee_reason_no_current": {
+                "default": "mdi:alert-circle"
+            }
+        },
+        "switch": {
+            "cable_locked_permanently": {
+                "default": "mdi:lock"
+            },
+            "idle_current": {
+                "default": "mdi:current-ac"
+            },
+            "smart_button": {
+                "default": "mdi:gesture-tap-button"
+            },
+            "is_enabled": {
+                "default": "mdi:power-standby"
+            },
+            "smart_charging": {
+                "default": "mdi:auto-fix"
+            }
+        }
+    },
+    "services": {
+        "action_command": "mdi:apple-keyboard-command",
+        "set_basic_charge_plan": "mdi:clock-check",
+        "set_charger_access": "mdi:cloud-key-outline",
+        "set_charger_dynamic_limit": "mdi:arrow-collapse-right",
+        "set_charger_max_limit": "mdi:arrow-collapse-right",
+        "set_charging_cost": "mdi:cash-multiple",
+        "set_circuit_dynamic_limit": "mdi:arrow-collapse-right",
+        "set_circuit_max_limit": "mdi:arrow-collapse-right",
+        "set_circuit_offline_limit": "mdi:arrow-collapse-right",
+        "set_weekly_charge_plan": "mdi:clock-check",
+        "smart_charging": "mdi:auto-fix"
+    }
+}

--- a/custom_components/easee/icons.json
+++ b/custom_components/easee/icons.json
@@ -24,7 +24,10 @@
         },
         "switch": {
             "cable_locked_permanently": {
-                "default": "mdi:lock"
+                "default": "mdi:lock",
+                "state": {
+                    "off": "mdi:lock-open"
+                }
             },
             "idle_current": {
                 "default": "mdi:current-ac"

--- a/custom_components/easee/services.py
+++ b/custom_components/easee/services.py
@@ -1,4 +1,5 @@
 """easee services."""
+
 from datetime import timedelta
 import logging
 
@@ -387,9 +388,8 @@ async def async_setup_services(hass):  # noqa: C901
     async def charger_set_schedule(call):
         """Execute a set schedule call to Easee charging station."""
         charger = await async_get_charger(call)
-        schedule_id = (
-            charger.id
-        )  # future versions of Easee API will allow multiple schedules, i.e. work-in-progress
+        # future versions of Easee API will allow multiple schedules, i.e. work-in-progress
+        schedule_id = charger.id
         start_datetime = call.data.get(ATTR_CHARGEPLAN_START_DATETIME)
         stop_datetime = call.data.get(ATTR_CHARGEPLAN_STOP_DATETIME)
         repeat = call.data.get(ATTR_CHARGEPLAN_REPEAT)
@@ -446,7 +446,7 @@ async def async_setup_services(hass):  # noqa: C901
             function_call = getattr(charger, function_name["function_call"])
             now_dt = dt_util.now()
             now_wd = now_dt.weekday()
-            now_td = timedelta(days=(now_wd - day))
+            now_td = timedelta(days=now_wd - day)
             now_dt = now_dt - now_td
             start_dt = dt_util.as_utc(
                 now_dt.replace(
@@ -526,7 +526,9 @@ async def async_setup_services(hass):  # noqa: C901
             function_call = getattr(circuit, function_name["function_call"])
             try:
                 if time_to_live is not None:
-                    return await function_call(current_p1, current_p2, current_p3, time_to_live)
+                    return await function_call(
+                        current_p1, current_p2, current_p3, time_to_live
+                    )
                 else:
                     return await function_call(current_p1, current_p2, current_p3)
             except BadRequestException as ex:


### PR DESCRIPTION
HA recommends using icon translations instead of assigning the icons as entity attributes. Service icons will also soon be mandatory.
Also removed black formatter from .pre-commit-config.yaml since it caused instability in the formatting. It should really have been removed when we went over to ruff.