### PR TITLE
Change method for excluding Equalizers

### DIFF
--- a/custom_components/easee/services.yaml
+++ b/custom_components/easee/services.yaml
@@ -12,7 +12,7 @@ action_command:
           integration: "easee"
           # This is needed to exclude Equalizers from the target list"
           entity:
-            device_class: "monetary"
+            domain: "switch"
     action_command:
       name: "Action command"
       description: "Select the command to execute"
@@ -55,7 +55,7 @@ set_basic_charge_plan:
         device:
           integration: "easee"
           entity:
-            device_class: "monetary"
+            domain: "switch"
     start_datetime:
       name: "Start datetime"
       description: "Plan start time"
@@ -91,7 +91,7 @@ set_weekly_charge_plan:
         device:
           integration: "easee"
           entity:
-            device_class: "monetary"
+            domain: "switch"
     day:
       name: "Day"
       description: "Schedule for day, 0 = monday"
@@ -142,7 +142,7 @@ smart_charging:
         device:
           integration: "easee"
           entity:
-            device_class: "monetary"
+            domain: "switch"
     enable:
       name: "Enable"
       description: "Enable smart charging"
@@ -164,7 +164,7 @@ set_circuit_max_limit:
         device:
           integration: "easee"
           entity:
-            device_class: "monetary"
+            domain: "switch"
     currentP1:
       name: "Current Phase 1"
       required: true
@@ -218,7 +218,7 @@ set_circuit_offline_limit:
         device:
           integration: "easee"
           entity:
-            device_class: "monetary"
+            domain: "switch"
     currentP1:
       name: "Current Phase 1"
       required: true
@@ -272,7 +272,7 @@ set_charger_dynamic_limit:
         device:
           integration: "easee"
           entity:
-            device_class: "monetary"
+            domain: "switch"
     current:
       name: "Current"
       required: true
@@ -300,7 +300,7 @@ set_circuit_dynamic_limit:
         device:
           integration: "easee"
           entity:
-            device_class: "monetary"
+            domain: "switch"
     currentP1:
       name: "Current Phase 1"
       required: true
@@ -367,7 +367,7 @@ set_charger_max_limit:
         device:
           integration: "easee"
           entity:
-            device_class: "monetary"
+            domain: "switch"
     current:
       name: "Current"
       required: true
@@ -395,7 +395,7 @@ set_charging_cost:
         device:
           integration: "easee"
           entity:
-            device_class: "monetary"
+            domain: "switch"
     cost_per_kwh:
       name: "Cost per kWh"
       description: "Cost per kWh"
@@ -439,7 +439,7 @@ set_charger_access:
         device:
           integration: "easee"
           entity:
-            device_class: "monetary"
+            domain: "switch"
     access_level:
       name: "Access level"
       description: "Select one of the levels"


### PR DESCRIPTION
We have to make the device selector to exclude Equalizers from service targets. Previously we used device_class == "monetary" to ensure that only chargers were listed. But if the user diabled all monetary sensors on their charger  no target device could be found. We now change to requiering that the device contains a switch platform. This method cannot be blocked by the user.