### PR TITLE
Fix for an exception in check_latest_pulse

### DIFF
--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -336,7 +336,10 @@ class ProductData:
             return
 
         now = dt_util.utcnow().replace(microsecond=0)
-        elapsed = now - self.state["latestPulse"]
+        try:
+            elapsed = now - self.state["latestPulse"]
+        except KeyError:
+            return
 
         if elapsed.total_seconds() > OFFLINE_DELAY:
             if self.state["isOnline"] is True:


### PR DESCRIPTION
If the latestPulse value was not yet populated this would fail.