### PR TITLE
Easee one support

### DIFF
--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -757,7 +757,10 @@ class Controller:
                 try:
                     compare_p1 = charger_data.state[compare_str_p1]
                 except KeyError:
-                    compare_p1 = charger_data.config[compare_str_p1]
+                    try:
+                        compare_p1 = charger_data.config[compare_str_p1]
+                    except KeyError:
+                        compare_p1 = None
                 try:
                     compare_p2 = charger_data.state[compare_str_p2]
                 except KeyError:
@@ -803,7 +806,10 @@ class Controller:
                 try:
                     compare_p1 = charger_data.state[compare_str_p1]
                 except KeyError:
-                    compare_p1 = charger_data.config[compare_str_p1]
+                    try:
+                        compare_p1 = charger_data.config[compare_str_p1]
+                    except KeyError:
+                        compare_p1 = None
                 try:
                     compare_p2 = charger_data.state[compare_str_p2]
                 except KeyError:

--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -411,7 +411,7 @@ class ProductData:
                     value = "{}"
                 self.schedules_interpret(json.loads(value))
             else:
-                _LOGGER.debug("Unkonwn update type: %s", first)
+                _LOGGER.debug("Unknown update type: %s", first)
 
         return False
 
@@ -742,9 +742,9 @@ class Controller:
         current_p1,
         current_p2,
         current_p3,
-        compare_p1,
-        compare_p2,
-        compare_p3,
+        compare_str_p1,
+        compare_str_p2,
+        compare_str_p3,
     ):
         """Check circuit current."""
         if current_p2 is None:
@@ -755,17 +755,27 @@ class Controller:
         for charger_data in self.chargers_data:
             if charger_data.circuit.id == circuit_id:
                 try:
-                    if (
-                        charger_data.state[compare_p1] != current_p1
-                        or charger_data.state[compare_p2] != current_p2
-                        or charger_data.state[compare_p3] != current_p3
-                    ):
-                        return charger_data.circuit
+                    compare_p1 = charger_data.state[compare_str_p1]
                 except KeyError:
-                    if (
-                        charger_data.config[compare_p1] != current_p1
-                        or charger_data.config[compare_p2] != current_p2
-                        or charger_data.config[compare_p3] != current_p3
+                    compare_p1 = charger_data.config[compare_str_p1]
+                try:
+                    compare_p2 = charger_data.state[compare_str_p2]
+                except KeyError:
+                    try:
+                        compare_p2 = charger_data.config[compare_str_p2]
+                    except KeyError:
+                        compare_p2 = compare_p1
+                try:
+                    compare_p3 = charger_data.state[compare_str_p3]
+                except KeyError:
+                    try:
+                        compare_p3 = charger_data.config[compare_str_p3]
+                    except KeyError:
+                        compare_p3 = compare_p1
+
+                if (compare_p1 != current_p1
+                    or compare_p2 != current_p2
+                    or compare_p3 != current_p3
                     ):
                         return charger_data.circuit
 
@@ -778,9 +788,9 @@ class Controller:
         current_p1,
         current_p2,
         current_p3,
-        compare_p1,
-        compare_p2,
-        compare_p3,
+        compare_str_p1,
+        compare_str_p2,
+        compare_str_p3,
     ):
         """Check charger current."""
         if current_p2 is None:
@@ -791,17 +801,27 @@ class Controller:
         for charger_data in self.chargers_data:
             if charger_data.product.id == charger_id:
                 try:
-                    if (
-                        charger_data.state[compare_p1] != current_p1
-                        or charger_data.state[compare_p2] != current_p2
-                        or charger_data.state[compare_p3] != current_p3
-                    ):
-                        return charger_data.product
+                    compare_p1 = charger_data.state[compare_str_p1]
                 except KeyError:
-                    if (
-                        charger_data.config[compare_p1] != current_p1
-                        or charger_data.config[compare_p2] != current_p2
-                        or charger_data.config[compare_p3] != current_p3
+                    compare_p1 = charger_data.config[compare_str_p1]
+                try:
+                    compare_p2 = charger_data.state[compare_str_p2]
+                except KeyError:
+                    try:
+                        compare_p2 = charger_data.config[compare_str_p2]
+                    except KeyError:
+                        compare_p2 = compare_p1
+                try:
+                    compare_p3 = charger_data.state[compare_str_p3]
+                except KeyError:
+                    try:
+                        compare_p3 = charger_data.config[compare_str_p3]
+                    except KeyError:
+                        compare_p3 = compare_p1
+
+                if (compare_p1 != current_p1
+                    or compare_p2 != current_p2
+                    or compare_p3 != current_p3
                     ):
                         return charger_data.product
 

--- a/custom_components/easee/entity.py
+++ b/custom_components/easee/entity.py
@@ -258,6 +258,7 @@ class ChargerEntity(Entity):
             self.data.product.id,
             self._entity_name,
         )
+        self._state = None
         try:
             self._state = self.get_value_from_key(self._state_key)
             if self._state == "":
@@ -275,7 +276,7 @@ class ChargerEntity(Entity):
                 self._state = self._convert_units_func(self._state, self._units)
 
         except KeyError:
-            self._state = None
+            pass
         except IndexError as exc:
             raise IndexError(f"Wrong key for entity: {self._state_key}") from exc
         except TypeError:


### PR DESCRIPTION
Changes to support Easee One, which is a 1 phase version of the Easee charger.
This means it does not return data for more than P1 keys, so we need to check if they are present before using them.