### PR TITLE
New version of pyeasee and bump version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-__VERSION__ = "0.9.60"
+__VERSION__ = "0.9.61"
 
 bump:
 	bump2version --allow-dirty --current-version $(__VERSION__) patch Makefile custom_components/easee/const.py custom_components/easee/manifest.json

--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.entity import EntityCategory
 
 DOMAIN = "easee"
 TIMEOUT = 30
-VERSION = "0.9.60"
+VERSION = "0.9.61"
 MIN_HA_VERSION = "2024.5.0"
 CONF_MONITORED_SITES = "monitored_sites"
 MANUFACTURER = "Easee"

--- a/custom_components/easee/manifest.json
+++ b/custom_components/easee/manifest.json
@@ -15,7 +15,7 @@
     "pyeasee"
   ],
   "requirements": [
-    "pyeasee==0.8.3"
+    "pyeasee==0.8.4"
   ],
-  "version": "0.9.60"
+  "version": "0.9.61"
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [bumpversion]
-current_version = 0.9.60
+current_version = 0.9.61
 
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
 doctests = True
 max-line-length = 88
-ignore =
+ignore = 
 	E501,
 	W503,
 	E203,


### PR DESCRIPTION
pyeasee 0.8.4: workaround for signalr lib reconnect issue.