### PR TITLE
Add button entity for override_schedule action

### DIFF
--- a/custom_components/easee/button.py
+++ b/custom_components/easee/button.py
@@ -1,0 +1,37 @@
+"""Easee charger button entity."""
+
+import logging
+
+from pyeasee.exceptions import ForbiddenServiceException
+
+from homeassistant.components.button import ButtonEntity
+
+from .const import DOMAIN
+from .entity import ChargerEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up button platform."""
+    controller = hass.data[DOMAIN]["controller"]
+    entities = controller.get_button_entities()
+    async_add_entities(entities)
+    await controller.setup_done("button")
+
+
+class ChargerButton(ChargerEntity, ButtonEntity):
+    """Easee button class."""
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        _LOGGER.debug("%s Button press", self._entity_name)
+        function_call = getattr(self.data.product, self._switch_func)
+        try:
+            await function_call()
+        except ForbiddenServiceException:
+            _LOGGER.error("Forbidden to press the button %s", self._entity_name)
+            return
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.error("Got server error while calling %s", self._switch_func)
+            return

--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -17,13 +17,13 @@ from homeassistant.helpers.entity import EntityCategory
 
 DOMAIN = "easee"
 TIMEOUT = 30
-VERSION = "0.9.64"
+VERSION = "0.9.64ake"
 MIN_HA_VERSION = "2024.8.0"
 CONF_MONITORED_SITES = "monitored_sites"
 MANUFACTURER = "Easee"
 MODEL_EQUALIZER = "Equalizer"
 MODEL_CHARGING_ROBOT = "Charging Robot"
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.BUTTON, Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
 LISTENER_FN_CLOSE = "update_listener_close_fn"
 EASEE_PRODUCT_CODES = {
     1: "Easee Home",
@@ -724,6 +724,16 @@ OPTIONAL_EASEE_ENTITIES = {
         "state_class": SensorStateClass.MEASUREMENT,
         "enabled_default": True,
         "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    "override_schedule": {
+        "type": "button",
+        "key": "",
+        "attrs": [],
+        "units": None,
+        "convert_units_func": None,
+        "device_class": None,
+        "switch_func": "override_schedule",
+        "translation_key": "override_schedule",
     },
 }
 

--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -40,6 +40,7 @@ from homeassistant.helpers.event import (
 from homeassistant.util import dt as dt_util
 
 from .binary_sensor import ChargerBinarySensor, EqualizerBinarySensor
+from .button import ChargerButton
 from .const import (
     CONF_MONITORED_SITES,
     DOMAIN,
@@ -63,6 +64,7 @@ from .switch import ChargerSwitch
 ENTITY_TYPES = {
     "sensor": ChargerSensor,
     "binary_sensor": ChargerBinarySensor,
+    "button": ChargerButton,
     "switch": ChargerSwitch,
     "eq_sensor": EqualizerSensor,
     "eq_binary_sensor": EqualizerBinarySensor,
@@ -442,6 +444,7 @@ class Controller:
         self.equalizers: list[Equalizer] = []
         self.equalizers_data: list[ProductData] = []
         self.binary_sensor_entities = []
+        self.button_entities = []
         self.switch_entities = []
         self.sensor_entities = []
         self.equalizer_sensor_entities = []
@@ -857,6 +860,10 @@ class Controller:
         """Get binary sensor entities."""
         return self.binary_sensor_entities + self.equalizer_binary_sensor_entities
 
+    def get_button_entities(self):
+        """Get button entities."""
+        return self.button_entities
+
     def get_sensor_entities(self):
         """Get sensor entities."""
         return self.sensor_entities + self.equalizer_sensor_entities
@@ -908,6 +915,9 @@ class Controller:
         elif object_type == "binary_sensor":
             self.binary_sensor_entities.append(entity)
 
+        elif object_type == "button":
+            self.button_entities.append(entity)
+
         elif object_type == "eq_sensor":
             self.equalizer_sensor_entities.append(entity)
 
@@ -920,6 +930,7 @@ class Controller:
         self.sensor_entities = []
         self.switch_entities = []
         self.binary_sensor_entities = []
+        self.button_entities = []
         self.equalizer_sensor_entities = []
         self.equalizer_binary_sensor_entities = []
 

--- a/custom_components/easee/icons.json
+++ b/custom_components/easee/icons.json
@@ -11,6 +11,11 @@
                 "default": "mdi:clock-check"
             }
         },
+        "button": {
+            "override_schedule": {
+                "default": "mdi:clock-start"
+            }
+        },
         "sensor": {
             "easee_status": {
                 "default": "mdi:ev-station"

--- a/custom_components/easee/translations/en.json
+++ b/custom_components/easee/translations/en.json
@@ -125,6 +125,11 @@
         "name": "Weekly schedule"
       }
     },
+    "button": {
+      "override_schedule": {
+        "name": "Override schedule"
+      }
+    },
     "sensor": {
       "circuit_current": {
         "name": "Circuit current"


### PR DESCRIPTION
Add a button entity for executing the override_schedule action command from the UI.
Additional buttons can easily be created for remaining action commands if desired.