### PR TITLE
Changes to sensor configs

### DIFF
--- a/custom_components/easee/const.py
+++ b/custom_components/easee/const.py
@@ -300,14 +300,15 @@ OPTIONAL_EASEE_ENTITIES = {
         "state_class": SensorStateClass.TOTAL_INCREASING,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
-    "energy_per_hour": {
+    "energy_last_hour": {
         "key": "state.energyPerHour",
         "attrs": [],
         "units": UnitOfEnergy.KILO_WATT_HOUR,
         "convert_units_func": None,
         "suggested_display_precision": 1,
-        "translation_key": "energy_per_hour",
+        "translation_key": "energy_last_hour",
         "device_class": SensorDeviceClass.ENERGY,
+        "enabled_default": False,
         "entity_category": EntityCategory.DIAGNOSTIC,
     },
     "cost_day": {
@@ -363,7 +364,10 @@ OPTIONAL_EASEE_ENTITIES = {
             "state.latestPulse",
             "config.wiFiSSID",
             "state.wiFiAPEnabled",
+            "config.wiFiAddress",
+            "config.wiFiMACAddress",
             "state.wiFiRSSI",
+            "config.cellAddress",
             "state.cellRSSI",
             "state.localRSSI",
         ],

--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -13,7 +13,6 @@ from pyeasee import (
     ChargerStreamData,
     ChargerWeeklySchedule,
     Circuit,
-    DatatypesStreamData,
     Easee,
     Equalizer,
     EqualizerStreamData,

--- a/custom_components/easee/translations/en.json
+++ b/custom_components/easee/translations/en.json
@@ -217,6 +217,9 @@
       "energy_per_hour": {
         "name": "Energy per hour"
       },
+      "energy_last_hour": {
+        "name": "Energy last hour"
+      },
       "equalizer_limit": {
         "name": "Equalizer limit"
       },


### PR DESCRIPTION
Sensor energy_per_hour changed name changed to energy_last_hour and disabled by default to hopefully cause less confusion about what it means/does.
A few more diagnostic attributes added to charger online sensor.