### PR TITLE
fix: make currency id required

### DIFF
--- a/custom_components/easee/services.yaml
+++ b/custom_components/easee/services.yaml
@@ -357,7 +357,7 @@ set_charging_cost:
           mode: box
     currency_id:
       example: "EUR"
-      required: false
+      required: true
       selector:
         text:
           type: text


### PR DESCRIPTION
This makes the `currency_id` parameter required in the 'set_charging_cost' service. This change ensures compliance with the official Easee API [documentation](https://developer.easee.com/reference/post_api-sites-siteid-price), which specifies that currency_id is mandatory for the service to function correctly.