### PR TITLE
Remove uncessary call to async_cost_refresh

### DIFF
--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -614,9 +614,6 @@ class Controller:
         await self.async_refresh_sites_state()
         await self.async_refresh_equalizers_state()
         await asyncio.gather(
-            *[charger.async_cost_refresh() for charger in self.chargers_data]
-        )
-        await asyncio.gather(
             *[charger.async_firmware_refresh() for charger in self.chargers_data]
         )
         await asyncio.gather(


### PR DESCRIPTION
The removed calls are not needed since the update is triggered also by lifetime_energy updates, which happens also during startup.