### PR TITLE
Cost refresh updated to comply with 10 calls per hour limit

### DIFF
--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -128,25 +128,29 @@ class CostData:
 
     async def update_cost(self):
         """Poll cost data and notify observers."""
-        dt_end = dt_util.now().replace(microsecond=0)
-        dt_start = dt_util.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        costs_day = await self.site.get_cost_between_dates(
-            dt_util.as_utc(dt_start), dt_util.as_utc(dt_end)
-        )
-        await asyncio.sleep(1)
-        dt_start = dt_start.replace(day=1)
-        costs_month = await self.site.get_cost_between_dates(
-            dt_util.as_utc(dt_start), dt_util.as_utc(dt_end)
-        )
-        await asyncio.sleep(1)
-        dt_start = dt_start.replace(month=1)
-        costs_year = await self.site.get_cost_between_dates(
-            dt_util.as_utc(dt_start), dt_util.as_utc(dt_end)
-        )
-        _LOGGER.debug("Cost refreshed %s %s %s", costs_day, costs_month, costs_year)
-        self.notify_observers(costs_day, "day")
-        self.notify_observers(costs_month, "month")
-        self.notify_observers(costs_year, "year")
+        try:
+            dt_end = dt_util.now().replace(microsecond=0)
+            dt_start = dt_util.now().replace(hour=0, minute=0, second=0, microsecond=0)
+            costs_day = await self.site.get_cost_between_dates(
+                dt_util.as_utc(dt_start), dt_util.as_utc(dt_end)
+            )
+            await asyncio.sleep(1)
+            dt_start = dt_start.replace(day=1)
+            costs_month = await self.site.get_cost_between_dates(
+                dt_util.as_utc(dt_start), dt_util.as_utc(dt_end)
+            )
+            await asyncio.sleep(1)
+            dt_start = dt_start.replace(month=1)
+            costs_year = await self.site.get_cost_between_dates(
+                dt_util.as_utc(dt_start), dt_util.as_utc(dt_end)
+            )
+        except Exception as ex:
+            _LOGGER.error("Cost refresh failed with exception %s", ex)
+        else:
+            _LOGGER.debug("Cost refreshed %s %s %s", costs_day, costs_month, costs_year)
+            self.notify_observers(costs_day, "day")
+            self.notify_observers(costs_month, "month")
+            self.notify_observers(costs_year, "year")
 
     def notify_observers(self, costs, name):
         """Send notification to observers."""


### PR DESCRIPTION
Since the cost polling API has 10 calls/hour limit, we need to make sure not to call it more often than every 20 minutes (given that we make 3 calls every time we call).
This also changes the implementation to use asyncio.queue instead of dqueue.