### PR TITLE
fix: Logger has no method print

### DIFF
--- a/custom_components/easee/controller.py
+++ b/custom_components/easee/controller.py
@@ -398,7 +398,7 @@ class ProductData:
             try:
                 first, second = name.split("_")
             except Exception as ex:  # pylint: disable=broad-except
-                _LOGGER.print("Exception %s when splitting %s", ex, name)
+                _LOGGER.debug("Exception %s when splitting %s", ex, name)
                 return False
 
             if first == "state":


### PR DESCRIPTION
I got an annoying error from `pyeasee.easee` that keep going for some times now.
```
AttributeError: 'HassLogger' object has no attribute 'print'
```

This PR replace the only  `_LOGGER.print` from the project to `_LOGGER.debug`